### PR TITLE
Fix Spring Boots default logging settings only work if 'default' profile is explicitely enabled

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,14 +2,25 @@
 <!DOCTYPE xml>
 <configuration>
 	<springProfile name="jsonlogging">
-		<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-			<encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+		<appender name="STDOUT"
+			class="ch.qos.logback.core.ConsoleAppender">
+			<encoder class="net.logstash.logback.encoder.LogstashEncoder">
+				<throwableConverter
+					class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+					<!-- default max size of one log line in docker is 16kb - UTF8 ~ 1 Character 
+						= 1 Byte -->
+					<maxLength>8096</maxLength>
+					<exclude>sun\.reflect\..*\.invoke.*</exclude>
+					<exclude>net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
+					<rootCauseFirst>true</rootCauseFirst>
+				</throwableConverter>
+			</encoder>
 		</appender>
 		<root level="info">
 			<appender-ref ref="STDOUT" />
 		</root>
 	</springProfile>
-	<springProfile name="default">
+	<springProfile name="!jsonlogging">
 		<include resource="org/springframework/boot/logging/logback/base.xml" />
 	</springProfile>
 </configuration>


### PR DESCRIPTION
**Description**

Fix Spring Boots default logging settings only work if 'default' profile is explicitely enabled

