### PR TITLE
Provide native image builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,4 +41,76 @@ jobs:
           REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export IMAGE_TAGS="${IMAGE_RAW_TAGS//$'\n'/,}"
-          mvn -B -ntp -P build-image,publish verify
+          mvn -B -ntp -P ci,build-image,publish package
+
+  build-maven-native:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+      - name: Build with Maven
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}-native
+          IMAGE_RAW_TAGS: ${{ steps.meta.outputs.tags }}
+          REGISTRY_USER: ${{ github.repository_owner }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export IMAGE_TAGS="${IMAGE_RAW_TAGS//$'\n'/,}"
+          mvn -B -ntp -P ci,native,build-native-image,publish package
+
+  build-maven-native-keycloak:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+      - name: Build with Maven
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}-native-keycloak
+          IMAGE_RAW_TAGS: ${{ steps.meta.outputs.tags }}
+          REGISTRY_USER: ${{ github.repository_owner }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export IMAGE_TAGS="${IMAGE_RAW_TAGS//$'\n'/,}"
+          mvn -B -ntp -P ci,native,keycloak,build-native-image,publish package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
           tags: |
             type=raw,value=${{ github.event.inputs.release-version }}
             ${{ (github.event.inputs.latest-image == 'y' && 'type=raw,value=latest') || '' }}
-      - name: Build with Maven
+      - name: Build image
         env:
           IMAGE_NAME: ghcr.io/${{ github.repository }}
           IMAGE_RAW_TAGS: ${{ steps.meta.outputs.tags }}
@@ -84,7 +84,29 @@ jobs:
         run: |
           export IMAGE_TAGS="${IMAGE_RAW_TAGS//$'\n'/,}"
           if [[ $LATEST_TAG == "y" ]]; then export IMAGE_TAGS=$IMAGE_TAGS,ghcr.io/it-at-m/appswitcher-server:latest; fi
-          mvn -B -ntp -DskipTests -P build-image,publish verify
+          mvn -B -ntp -DskipTests -P ci,build-image,publish verify
+      - name: Build native image (default profile)
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}-native
+          IMAGE_RAW_TAGS: ${{ steps.meta.outputs.tags }}
+          REGISTRY_USER: ${{ github.repository_owner }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST_TAG: ${{ (github.event.inputs.latest-image == 'y' && 'y') || 'n' }}
+        run: |
+          export IMAGE_TAGS="${IMAGE_RAW_TAGS//$'\n'/,}"
+          if [[ $LATEST_TAG == "y" ]]; then export IMAGE_TAGS=$IMAGE_TAGS,$IMAGE_NAME:latest; fi
+          mvn -B -ntp -DskipTests -P ci,native,build-native-image,publish verify
+      - name: Build native image  (keycloak profile)
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}-native-keycloak
+          IMAGE_RAW_TAGS: ${{ steps.meta.outputs.tags }}
+          REGISTRY_USER: ${{ github.repository_owner }}
+          REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST_TAG: ${{ (github.event.inputs.latest-image == 'y' && 'y') || 'n' }}
+        run: |
+          export IMAGE_TAGS="${IMAGE_RAW_TAGS//$'\n'/,}"
+          if [[ $LATEST_TAG == "y" ]]; then export IMAGE_TAGS=$IMAGE_TAGS,$IMAGE_NAME:latest; fi
+          mvn -B -ntp -DskipTests -P ci,keycloak,native,build-native-image,publish verify
       - name: Create GitHub Release
         id: create_release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Keycloak integration can be enabled by enabling the Spring profile `keycloak` (s
 
 You can use the official container image [ghrc.io/it-at-m/appswitcher-server](https://github.com/it-at-m/appswitcher-server/pkgs/container/appswitcher-server). To provide your [custom Applications](#custom-applications) create a custom `application.yml` containing your applications under the key `appswitcher.apps.*` and mount the file as a volume at `/workspace/config/application.yml`.
 
+If you prefer to run a native image for faster startup times, there a two image variants available:
+
+- [ghrc.io/it-at-m/appswitcher-server-native](https://github.com/it-at-m/appswitcher-server/pkgs/container/appswitcher-server-native)
+- [ghrc.io/it-at-m/appswitcher-server-native-keycloak](https://github.com/it-at-m/appswitcher-server/pkgs/container/appswitcher-server-native-keycloak) (for [Keycloak integration](#keycloak-integration) support)
+
+
 ### Kubernetes
 
 If you want to deploy appswitcher-server on a Kubernetes cluster, you can use the [official Helm chart][helm-chart-github].

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<image.name>itatm/${project.artifactId}:${project.version}</image.name>
+		<image.name>itatm/${project.artifactId}</image.name>
 	</properties>
 
 	<dependencies>
@@ -116,6 +116,11 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<!-- native image building -->
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
@@ -176,6 +181,7 @@
 						<goals>
 							<goal>check</goal>
 						</goals>
+						<phase>test</phase>
 					</execution>
 				</executions>
 			</plugin>
@@ -211,6 +217,7 @@
 						<goals>
 							<goal>check</goal>
 						</goals>
+						<phase>test</phase>
 					</execution>
 				</executions>
 			</plugin>
@@ -247,10 +254,33 @@
 
 	<profiles>
 		<profile>
-			<id>build-image</id>
+			<id>lhm</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<docker>
+								<builderRegistry>
+									<username>${env.DOCKERHUB_USERNAME}</username>
+									<password>${env.DOCKERHUB_PASSWORD}</password>
+									<url>https://index.docker.io/v1/</url>
+								</builderRegistry>
+							</docker>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>ci</id>
 			<properties>
 				<image.name>${env.IMAGE_NAME}</image.name>
 			</properties>
+		</profile>
+		<profile>
+			<id>build-image</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -265,13 +295,14 @@
 									<NO_PROXY>${env.NO_PROXY}</NO_PROXY>
 									<BP_HEALTH_CHECKER_ENABLED>true</BP_HEALTH_CHECKER_ENABLED>
 								</env>
+								<verboseLogging>true</verboseLogging>
 								<tags>${env.IMAGE_TAGS}</tags>
 								<builder>paketobuildpacks/builder-jammy-base:latest</builder>
 								<buildpacks>
 									<buildpack>
 										urn:cnb:builder:paketo-buildpacks/java</buildpack>
 									<buildpack>
-										gcr.io/paketo-buildpacks/health-checker:latest</buildpack>
+										docker.io/paketobuildpacks/health-checker:latest</buildpack>
 								</buildpacks>
 							</image>
 						</configuration>
@@ -281,6 +312,66 @@
 								<goals>
 									<goal>build-image-no-fork</goal>
 								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>build-native-image</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<image>
+								<name>${image.name}:${project.version}</name>
+								<env>
+									<HTTP_PROXY>${env.HTTP_PROXY}</HTTP_PROXY>
+									<HTTPS_PROXY>${env.HTTPS_PROXY}</HTTPS_PROXY>
+									<NO_PROXY>${env.NO_PROXY}</NO_PROXY>
+									<BP_HEALTH_CHECKER_ENABLED>true</BP_HEALTH_CHECKER_ENABLED>
+								</env>
+								<verboseLogging>true</verboseLogging>
+								<tags>${env.IMAGE_TAGS}</tags>
+								<builder>paketobuildpacks/builder-jammy-base:latest</builder>
+								<buildpacks>
+									<buildpack>
+										urn:cnb:builder:paketo-buildpacks/java</buildpack>
+									<buildpack>
+										urn:cnb:builder:paketo-buildpacks/native-image</buildpack>
+									<buildpack>
+										docker.io/paketobuildpacks/health-checker:latest</buildpack>
+								</buildpacks>
+							</image>
+						</configuration>
+						<executions>
+							<execution>
+								<id>build-image</id>
+								<goals>
+									<goal>build-image-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>keycloak</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>process-aot</id>
+								<configuration>
+									<profiles>keycloak</profiles>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>

--- a/src/main/java/de/muenchen/oss/appswitcher/AppswitcherProperties.java
+++ b/src/main/java/de/muenchen/oss/appswitcher/AppswitcherProperties.java
@@ -22,6 +22,7 @@
  */
 package de.muenchen.oss.appswitcher;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -36,7 +37,7 @@ import lombok.Data;
 public class AppswitcherProperties {
 
     @NestedConfigurationProperty
-    private Map<String, AppConfigurationProperties> apps;
+    private Map<String, AppConfigurationProperties> apps = new LinkedHashMap<>();
 
     @NestedConfigurationProperty
     private KeycloakConfigurationProperties keycloak;


### PR DESCRIPTION
**Description**

- [x] integrate `native` maven profile in build
- [x] `keycloak` profile support
  - [x] blocked by https://github.com/paketo-buildpacks/native-image/issues/132 - currently unable to add custom CA certificates (if Keycloak uses custom CA certificates like we do internally at it@M) 
- [x] thymeleaf with configuration props: https://github.com/spring-projects/spring-boot/issues/36684
- [x] run internally on Windows w. Docker Desktop: https://github.com/spring-projects/spring-boot/issues/36671
  - workaround see https://github.com/spring-projects/spring-boot/issues/36671#issuecomment-1663370400 

**Reference**

closes #24
