### PR TITLE
Update spring-boot maven plugin builder image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,7 @@
 									<NO_PROXY>${env.NO_PROXY}</NO_PROXY>
 								</env>
 								<tags>${env.IMAGE_TAGS}</tags>
+								<builder>paketobuildpacks/builder-jammy-base:latest</builder>
 							</image>
 						</configuration>
 						<executions>


### PR DESCRIPTION
bionic based builder image is out of support, https://spring.io/blog/2023/09/22/paketo-buildpacks-bionic-end-of-support