### PR TITLE
Add health-checker to buildpacks config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,9 @@
     THE SOFTWARE.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -263,10 +265,16 @@
 									<HTTP_PROXY>${env.HTTP_PROXY}</HTTP_PROXY>
 									<HTTPS_PROXY>${env.HTTPS_PROXY}</HTTPS_PROXY>
 									<NO_PROXY>${env.NO_PROXY}</NO_PROXY>
+									<BP_HEALTH_CHECKER_ENABLED>true</BP_HEALTH_CHECKER_ENABLED>
 								</env>
 								<tags>${env.IMAGE_TAGS}</tags>
-								<builder>
-									paketobuildpacks/builder-jammy-base:latest</builder>
+								<builder>paketobuildpacks/builder-jammy-base:latest</builder>
+								<buildpacks>
+									<buildpack>
+										urn:cnb:builder:paketo-buildpacks/java</buildpack>
+									<buildpack>
+										gcr.io/paketo-buildpacks/health-checker:latest</buildpack>
+								</buildpacks>
 							</image>
 						</configuration>
 						<executions>


### PR DESCRIPTION
Add health-checker to buildpacks config, contributes health-check utility into image

**Description**

contributes health-check script to `/workspace/health-check`, which can be used for a Docker HEALTHCHECK, e.g.

```
docker run -it -e THC_PATH=/actuator/health/liveness --health-cmd /workspace/health-check --health-interval 1s --health-timeout 2s --health-retries 2 --health-start-period 15s -p 8080:8080 ghcr.io/itatm/appswitcher-server
```

**Reference**

https://github.com/it-at-m/refarch-templates/issues/634
